### PR TITLE
Added setproctitle to adjust ps output.

### DIFF
--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -1,5 +1,5 @@
 from quart import Quart,request, jsonify
-import json, requests, logging, logging.handlers, socket, asyncio, os, argparse, dateutil.parser, time
+import json, requests, logging, logging.handlers, socket, asyncio, os, argparse, dateutil.parser, time, setproctitle
 from ipaddress import IPv4Address, IPv4Network
 from dis_client_sdk import DisClient
 from pathlib import Path
@@ -571,6 +571,11 @@ total_source_ips_reported = 0
 
 if args.log_report_stats:
     start_status_reporting(args.log_report_stats)
+
+# Ready to run, now hide command line arguments and change my process name
+# for easier monitoring and hide api keys from cli. Not 100% failsafe but
+# ok-ish
+setproctitle.setproctitle(args.log_prefix)
 
 app.run(debug=args.debug, host=args.bind_address, port=args.bind_port,
         certfile=cert_chain_filename, keyfile=cert_key_filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ Quart==0.6.15
   multidict==4.5.2
   sortedcontainers==2.1.0
 wheel==0.34.2
+setproctitle>=1.2.1


### PR DESCRIPTION
Added setproctitle to adjust two aspects, process monitoring. With the "python3 arbor-monitor etc" it's harder to do a simple process check if the
tool is running. Secondly the command line options are visible with all
api keys etc. This removed them from the output.
If the timing is right one can still see the command line options before
we're call setproctitle but this should work until an other approach is
defined.

before:
```
UID        PID  PPID  C STIME TTY          TIME CMD
root     16244 16227 16 07:49 ?        00:00:00 python3.6 /app/arbor-monitor --bind-port 8443 --webhook-token <<removed>> --arbor-api-prefix https://arbor.<<removed>> --arbor-api-token <<removed>> --report
```

after:
```
UID        PID  PPID  C STIME TTY          TIME CMD
root     16430 16413 24 07:50 ?        00:00:00 arbor-monitor
```
(Set to the same value as that from --log-prefix)