### PR TITLE
Integrate support for modifying the system process title to exclude keys and tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER_REGISTRY := community.cablelabs.com:4567
-DOCKER_IMAGE_TAG := stable
+DOCKER_IMAGE_TAG := latest
 DOCKER_IMAGE_PATH := dis-docker/dis-arbor-monitor:$(DOCKER_IMAGE_TAG)
 DOCKER_SAVE_FILE := dis-arbor-monitor-$(DOCKER_IMAGE_TAG)
 

--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -577,10 +577,19 @@ if args.log_report_stats:
 # for easier monitoring and hide api keys from cli. Not 100% failsafe but
 # ok-ish
 cur_proc_title = setproctitle.getproctitle()
+
+# TODO: REMOVE ME
 logger.info("Current proc title: " + cur_proc_title)
-cur_proc_title = cur_proc_title.replace(args.arbor_api_token, "ARBOR_API_TOKEN_HIDDEN") \
-                               .replace(args.report_consumer_api_key, "DIS_API_TOKEN_HIDDEN") \
-                               .replace(args.webhook_token, "WEBHOOK_TOKEN_HIDDEN")
+if args.arbor_api_token:
+    cur_proc_title = cur_proc_title.replace(args.arbor_api_token, "ARBOR_API_TOKEN_HIDDEN")
+
+if args.report_consumer_api_key:
+    cur_proc_title = cur_proc_title.replace(args.report_consumer_api_key, "DIS_API_TOKEN_HIDDEN")
+
+if args.webhook_token:
+    cur_proc_title = cur_proc_title.replace(args.webhook_token, "WEBHOOK_TOKEN_HIDDEN")
+
+# TODO: REMOVE ME
 logger.info("Adjusted proc title: " + cur_proc_title)
 setproctitle.setproctitle(cur_proc_title)
 

--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -573,24 +573,18 @@ total_source_ips_reported = 0
 if args.log_report_stats:
     start_status_reporting(args.log_report_stats)
 
-# Ready to run, now hide command line arguments and change my process name
-# for easier monitoring and hide api keys from cli. Not 100% failsafe but
-# ok-ish
+# Hide sensitive command line arguments
 cur_proc_title = setproctitle.getproctitle()
 
-# TODO: REMOVE ME
-logger.info("Current proc title: " + cur_proc_title)
 if args.arbor_api_token:
-    cur_proc_title = cur_proc_title.replace(args.arbor_api_token, "ARBOR_API_TOKEN_HIDDEN")
+    cur_proc_title = cur_proc_title.replace(args.arbor_api_token, "[token hidden]")
 
 if args.report_consumer_api_key:
-    cur_proc_title = cur_proc_title.replace(args.report_consumer_api_key, "DIS_API_TOKEN_HIDDEN")
+    cur_proc_title = cur_proc_title.replace(args.report_consumer_api_key, "[token hidden]")
 
 if args.webhook_token:
-    cur_proc_title = cur_proc_title.replace(args.webhook_token, "WEBHOOK_TOKEN_HIDDEN")
+    cur_proc_title = cur_proc_title.replace(args.webhook_token, "[token hidden]")
 
-# TODO: REMOVE ME
-logger.info("Adjusted proc title: " + cur_proc_title)
 setproctitle.setproctitle(cur_proc_title)
 
 app.run(debug=args.debug, host=args.bind_address, port=args.bind_port,

--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -576,7 +576,13 @@ if args.log_report_stats:
 # Ready to run, now hide command line arguments and change my process name
 # for easier monitoring and hide api keys from cli. Not 100% failsafe but
 # ok-ish
-setproctitle.setproctitle(args.log_prefix)
+cur_proc_title = setproctitle.getproctitle()
+logger.info("Current proc title: " + cur_proc_title)
+cur_proc_title = cur_proc_title.replace(args.arbor_api_token, "ARBOR_API_TOKEN_HIDDEN") \
+                               .replace(args.report_consumer_api_key, "DIS_API_TOKEN_HIDDEN") \
+                               .replace(args.webhook_token, "WEBHOOK_TOKEN_HIDDEN")
+logger.info("Adjusted proc title: " + cur_proc_title)
+setproctitle.setproctitle(cur_proc_title)
 
 app.run(debug=args.debug, host=args.bind_address, port=args.bind_port,
         certfile=cert_chain_filename, keyfile=cert_key_filename)

--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -1,5 +1,5 @@
 from quart import Quart,request, jsonify
-import json, requests, logging, logging.handlers, socket, asyncio, os, argparse, dateutil.parser, time
+import json, requests, logging, logging.handlers, socket, asyncio, os, argparse, dateutil.parser, time, setproctitle
 from ipaddress import IPv4Address, IPv4Network
 from dis_client_sdk import DisClient
 from pathlib import Path
@@ -572,6 +572,11 @@ total_source_ips_reported = 0
 
 if args.log_report_stats:
     start_status_reporting(args.log_report_stats)
+
+# Ready to run, now hide command line arguments and change my process name
+# for easier monitoring and hide api keys from cli. Not 100% failsafe but
+# ok-ish
+setproctitle.setproctitle(args.log_prefix)
 
 app.run(debug=args.debug, host=args.bind_address, port=args.bind_port,
         certfile=cert_chain_filename, keyfile=cert_key_filename)

--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -580,7 +580,7 @@ if args.arbor_api_token:
     cur_proc_title = cur_proc_title.replace(args.arbor_api_token, "[token hidden]")
 
 if args.report_consumer_api_key:
-    cur_proc_title = cur_proc_title.replace(args.report_consumer_api_key, "[token hidden]")
+    cur_proc_title = cur_proc_title.replace(args.report_consumer_api_key, "[key hidden]")
 
 if args.webhook_token:
     cur_proc_title = cur_proc_title.replace(args.webhook_token, "[token hidden]")

--- a/arbormon-container.conf
+++ b/arbormon-container.conf
@@ -1,7 +1,7 @@
 DOCKER_CMD="docker"
 
 DEF_IMAGE_LOCATION=community.cablelabs.com:4567/dis-docker/dis-arbor-monitor
-DEF_IMAGE_TAG=dissarm
+DEF_IMAGE_TAG=latest
 DEF_CONTAINER_NAME=dis-arbor-monitor-service
 DEF_TLS_CERT_CHAIN_FILE=
 DEF_TLS_PRIV_KEY_FILE=

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ Quart==0.6.15
   multidict==4.5.2
   sortedcontainers==2.1.0
 wheel==0.34.2
+setproctitle>=1.2.1


### PR DESCRIPTION
Example command line with this feature enabled:

`python arbor-monitor --bind-port 8443 --cert-chain-file /etc/crits-client/combined.cer --cert-key-file /etc/crits-client/private.key --arbor-api-prefix https://arbos01.acme.com --arbor-api-token [token hidden] --report-consumer-api-key [token hidden] --syslog-server localhost`

