### PR TITLE
Task/add dis client sdk workaround

### DIFF
--- a/arbor-monitor/dis_client_sdk/DisClient.py
+++ b/arbor-monitor/dis_client_sdk/DisClient.py
@@ -1,0 +1,127 @@
+import requests
+from typing import Dict
+from uuid import uuid4
+from pydantic import IPvAnyAddress
+from pydantic.types import Json, UUID4
+from typing import List, Optional
+from pydantic import BaseModel, Json, HttpUrl
+
+try:
+    from devtools import debug as print
+except:
+    pass
+
+
+class EventAttribute(BaseModel):
+    enum: str
+    name: str
+    value: Optional[str]
+    metadata: Optional[Json]
+
+
+class IpAttribute(BaseModel):
+    enum: str
+    name: str
+    value: Optional[str]
+    metadata: Optional[Json]
+
+
+class DisClient(object):
+    """SDK for the /data route for the DIS system.  Implements the REST API. """
+
+    def __init__(self, api_key: str, base_url: HttpUrl = "https://api.dissarm.net/v1"):
+        self._key = api_key
+        self._base_url = base_url
+        self._dest_url = f"{self._base_url}/data?api_key={self._key}"
+        self._events = {}
+        self._sent_events = []
+
+        res = requests.get(f"{base_url}/client/me?api_key={api_key}")
+
+        if res.status_code == 401:
+            raise Exception(
+                "Not authorized.  Check that your API Key is correct.")
+
+        if res.status_code >= 400:
+            raise Exception(res.json())
+
+        self._me = res.json()
+
+    def get_info(self):
+        return self._me
+
+    def get_dest(self):
+        return self._dest_url
+
+    def add_attack_event(self, start_timestamp: int,
+                         end_timestamp: int,
+                         attack_type: List[str] = None):
+        """Stages an Event Attack to the outgoing DIS ingestion data.  Returns an ID to be used to reference the event in the SDK"""
+
+        event_uuid = str(uuid4())
+        self._events[event_uuid] = {
+            "startTimestamp": start_timestamp,
+            "endTimestamp": end_timestamp,
+            "attackType": attack_type,
+            "ipAddressList": [],
+            "attributeList": []
+        }
+
+        return event_uuid
+
+    def update_event_end_timestamp(self, event_uuid: UUID4, end_timestamp: int):
+        """Updates the end timestamp of an attack event"""
+        self._events[event_uuid]["endTimestamp"] = end_timestamp
+
+    def add_attribute_to_event(self, event_uuid: UUID4, name: str, enum: str, value: str, metadata: Dict = None):
+        if not event_uuid in self._events:
+            raise Exception("Event does not exist")
+
+        self._events[event_uuid]["attributeList"].append({
+            "enum": enum,
+            "name": name,
+            "value": value,
+            "metadata": metadata
+        })
+
+    def add_attack_source_to_event(self,
+                                   event_uuid: UUID4,
+                                   ip: IPvAnyAddress,
+                                   start_timestamp: int = None,
+                                   end_timestamp: int = None,
+                                   attack_type: List[str] = None,
+                                   attribute_list: List[IpAttribute] = None):
+        """Adds an IP Address (attack source) to an existing Attack Event"""
+        if not event_uuid in self._events:
+            raise Exception("Event does not exist")
+
+        self._events[event_uuid]["ipAddressList"].append({
+            "ipAddress": ip,
+            "startTimestamp": start_timestamp,
+            "endTimestamp": end_timestamp,
+            "attackType": attack_type,
+            "attributeList": attribute_list
+        })
+
+    def get_staged_event_ids(self):
+        """Returns all staged event ids in DisClient"""
+        return [k for k, v in self._events.items()]
+
+    def send(self):
+        """Sends all staged attack events to DIS and clears staged events"""
+
+        events = []
+        for k, v in self._events.items():
+            events.append(v)
+
+        res = requests.post(self._dest_url, json={"events": events})
+
+        if res.status_code == 401:
+            raise Exception(
+                "Not authorized.  Check that your API Key is correct.")
+
+        if res.status_code >= 400:
+            raise Exception(res.json())
+
+        self._sent_events.append(self._events)
+        self._events = {}

--- a/arbor-monitor/dis_client_sdk/DisClient.py
+++ b/arbor-monitor/dis_client_sdk/DisClient.py
@@ -125,3 +125,23 @@ class DisClient(object):
 
         self._sent_events.append(self._events)
         self._events = {}
+
+    def send_one(self, event_uuid: UUID4):
+	# WORKAROUND SJC: Creat a send one function to workaround upload issues
+        """Sends one staged attack events to DIS"""
+
+        events = []
+        events.append(self._events[event_uuid])
+
+        res = requests.post(self._dest_url, json={"events": events})
+
+        if res.status_code == 401:
+            raise Exception(
+                "Not authorized.  Check that your API Key is correct.")
+
+        if res.status_code >= 400:
+            raise Exception(res.json())
+
+        self._sent_events.append(self._events)
+	# WORKAROUND SJC: clear anyway as the other ID's should be consider lost anyway
+        self._events = {}

--- a/arbor-monitor/dis_client_sdk/README.md
+++ b/arbor-monitor/dis_client_sdk/README.md
@@ -1,0 +1,84 @@
+# Client SDK
+
+The DIS Client SDK is a python wrapper intended to be used in conjunction with a DDoS reporting appliance such as Arbor. The SDK simply implements a simple interface for the [DIS REST API]().
+
+For some of more common DDoS appliances, there is a [Docker Container]() available for that utilizes this SDK.
+
+## Installation
+
+DIS Client is a python package available via `pip` and requires Python 3+.
+
+```
+pip install dis-client-sdk
+```
+
+## Example:
+
+After installing the SDK, retrieve your client [API Key from DIS]() and use it to instantiate the SDK:
+
+```python
+from dis_client_sdk import DisClient
+from time import time
+
+CLIENT_API_KEY="your-client-api-key-from-dis"
+
+client = DisClient(api_key=CLIENT_API_KEY)
+now = int(time())
+
+# get info about the client
+info = client.get_info()
+print("Client Name: ", info["name"])
+
+
+# Create an attack event that lasts for 10 seconds
+ev_id = client.add_attack_event(start_timestamp=now,
+                                end_timestamp=now+10,
+                                attack_type=["ICMP_FLOOD", "POD"])
+
+# Add an attribute to the attack event
+client.add_attribute_to_event(event_uuid=ev_id,
+                              name="myevent",
+                              enum="MY_EVENT",
+                              value="Test Value")
+
+# Add an attack source (IP)
+client.add_attack_source_to_event(ev_id,
+                                  ip="1.0.0.0",
+                                  attribute_list=[{
+                                      "enum": "SEVERITY",
+                                      "name": "Severity Level",
+                                      "value": "high"
+                                  },
+                                      {
+                                      "enum": "BPS",
+                                      "name": "Bytes per second",
+                                      "value": "1300"
+                                  }])
+
+# Gets all the event IDs staged for sending
+event_ids = client.get_staged_event_ids()
+
+# Send to DIS
+client.send()
+
+# Sent events are cleared from the staged events..check the dashboard to see your client metrics.
+
+
+```
+
+## API
+
+The SDK has a few methods:
+
+- `DisClient(api_key, base_url)` - constructor for the client. The `base_url` defaults to the DIS backend.
+- `add_attack_event(start_timestamp, end_timestamp, [attack_type])` - Adds an attack event. `attack_type` is an optional array of strings. Returns a staged event ID.
+- `add_attribute_to_event(event_id, name, enum, value, [metadata])` - Adds an attribute to an existing staged event and takes as an argument `name`, `enum`, and `value`. An optional `metadata` as JSON is included if desired.
+- `get_info()` - Returns information about the client, organization, and client type attributes. See (Client GET)[] api docs for return spec.
+- `add_attack_source_to_event(event_id, ip, [start_timestamp], [end_timestamp], [attack_type], [attribute_list])`. All optional parameters are included if ip information is different than the event. `attibuteList` takes a dictionary in the form `{name, enum, value, [metadata]}`.
+- `update_event_end_timestamp(event_id, end_timestamp)` - updates an event end timestamp if not known upon creation.
+- `get_staged_event_ids()` - returns list of staged event ids.
+- `send()` - sends all staged events. Clears the staged events upon successful sending.
+
+## License
+
+MIT license

--- a/arbor-monitor/dis_client_sdk/__init__.py
+++ b/arbor-monitor/dis_client_sdk/__init__.py
@@ -1,0 +1,5 @@
+from dis_client_sdk import DisClient as D
+DisClient = D.DisClient
+name = "dis_client_sdk"
+
+__version__ = '0.0.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,14 +18,6 @@
 
 Cython==0.29.14
 demjson==2.2.4
-dis-client-sdk==0.0.2
-  pydantic==1.6.1
-    dataclasses==0.7
-  requests==2.22.0
-    certifi==2019.11.28
-    chardet==3.0.4
-    idna==2.8
-    urllib3==1.25.7
 falcon==2.0.0
 gunicorn==20.0.0
   setuptools==45.1.0
@@ -41,6 +33,8 @@ jsonschema==3.2.0
   six==1.13.0
 pipdeptree==0.13.2
   pip==20.0.2
+pydantic==1.7.3
+  dataclasses==0.7
 python-dateutil==2.8.1
   six==1.13.0
 Quart==0.6.15
@@ -62,5 +56,10 @@ Quart==0.6.15
     MarkupSafe==1.1.1
   multidict==4.5.2
   sortedcontainers==2.1.0
+requests==2.25.1
+  certifi==2020.12.5
+  chardet==4.0.0
+  idna==2.10
+  urllib3==1.26.2
+setproctitle==1.2.1
 wheel==0.34.2
-setproctitle>=1.2.1


### PR DESCRIPTION
Craig,
I'm currently running with this version of the client. It does a number of things:

1. Even when the upload fails it will return a 200 http response as otherwise we'll be stuck on that attack as arbor continue to send the event over and over and we fail over and over in the upload.
2. This version with only work with the dis_client event id's, as obtained on [line 156](https://github.com/cablelabs/dis-arbor-monitor/blob/bd1a9b13cc29f6eb7a0b30de8746d43b8de9dc3d/arbor-monitor/__main__.py#L156). I'm not sure why we would want to upload or even work with multiple attacks in one go in this client approach (but I could be wrong of course).As such I also removed the call to "get_staged_event_ids" as there is no reason to obtain them anymore.
3.  Created a send_one function in dis client SDK so you can send one specific attack by eventid. I think I'm also clearing all lost eventid's but not entirely sure as I'm not a hardcore python coder :-)
4. The client is no longer logging prefixes that are not /32's to reduce logging for now.

As said this is what we/I'm currently running to test the various attack submissions into DIS. 
That said maybe we need to make the returning of the 200 on an upload failure to DIS a command line option? 
Whether we should only work with 1 eventid I'll leave that to you as you know the whole environment better then I do.