### PR TITLE
Fix for issue #10 (Client can't startup when backend is down)

### DIFF
--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -497,17 +497,21 @@ if args.dry_run:
     logger.info("RUNNING IN DRY-RUN MODE (not connecting/reporting to the DIS server)")
 else:
     dis_client = DisClient(api_key=args.report_consumer_api_key, staged_limit=args.max_queued_reports)
-    dis_client_info = dis_client.get_info()
-    logger.info(f"DIS client name: {dis_client_info.get('name')}")
-    org = dis_client_info.get("organization")
-    logger.info(f"DIS client organization: {org.get('name') if org else 'Unknown'}")
-    logger.info(f"DIS client description: {dis_client_info.get('shortDescription')}")
-    logger.info(f"DIS client contact: {org.get('contactEmail')}")
-    client_type = dis_client_info.get("clientType")
-    logger.info(f"Client type name: {client_type.get('name')}")
-    logger.info(f"Client type maker: {client_type.get('maker')}")
-    logger.info(f"Client type version: {client_type.get('version')}")
-    # TODO: Check the maker (and version?)
+
+    try:
+        dis_client_info = dis_client.get_info()
+        logger.info(f"DIS client name: {dis_client_info.get('name')}")
+        org = dis_client_info.get("organization")
+        logger.info(f"DIS client organization: {org.get('name') if org else 'Unknown'}")
+        logger.info(f"DIS client description: {dis_client_info.get('shortDescription')}")
+        logger.info(f"DIS client contact: {org.get('contactEmail')}")
+        client_type = dis_client_info.get("clientType")
+        logger.info(f"Client type name: {client_type.get('name')}")
+        logger.info(f"Client type maker: {client_type.get('maker')}")
+        logger.info(f"Client type version: {client_type.get('version')}")
+        # TODO: Check the maker (and version?)
+    except Exception as ex:
+        logger.warning(f"Error getting client info from DIS server: {ex}")
 
 # Note: Setting up syslog after logging above here - so the above doesn't go into syslog
 syslog_formatter = logging.Formatter("%(name)s: %(message)s")

--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -68,7 +68,7 @@ async def process_sightline_webhook_notification():
 
     response = get_src_traffic_report(attack_id)
     if response.status_code != 200:
-        msg=f"Error retrieving the source traffic report for attack {attack_id}: {response.reason} ({response.content}))"
+        msg=f"Error retrieving the source traffic report for attack {attack_id}: (HTTP Status: {response.status_code} ({response.reason})) ({response.content}))"
         logger.warning(msg)
         # Returning a 404 so Netscout so we can try to retrieve the report again
         return jsonify({"error": msg}), 404, {'Content-Type': 'application/json'}
@@ -115,7 +115,7 @@ def check_sightline_api_supported():
                             verify=not args.arbor_api_insecure,
                             headers={"X-Arbux-APIToken":args.arbor_api_token})
     if response.status_code != requests.codes.ok:
-        logger.error(f"Error retrieving {response.url}: Status code {response.status_code}")
+        logger.error(f"Error retrieving {response.url}: (HTTP Status: {response.status_code} ({response.reason}))")
         return False
 
     json_response = response.json()

--- a/arbor-monitor/dis_client_sdk/DisClient.py
+++ b/arbor-monitor/dis_client_sdk/DisClient.py
@@ -42,7 +42,7 @@ class DisClient(object):
             raise Exception("Not authorized.  Check that your API Key is correct.")
 
         if res.status_code != 200:
-            raise Exception(f"DIS server returned status code {res.status_code} accessing {self._base_url} ({res.reason})")
+            raise Exception(f"DIS server returned (HTTP Status: {res.status_code} ({res.reason})) accessing {self._base_url} ({res.reason})")
 
         return res.json()
 
@@ -117,14 +117,14 @@ class DisClient(object):
 
         if 200 <= res.status_code < 400:
             self._events = {}
-            return f"Sent {len(events)} events to {self._base_url} (status {res.status_code} ({res.reason}))"
+            return f"Sent {len(events)} events to {self._base_url} (HTTP Status: {res.status_code} ({res.reason}))"
 
         if 500 <= res.status_code < 600 or res.status_code == 401:
             # Can be remedied on the server side - throw an error but don't clear the queue
-            raise Exception(f"DIS server returned recoverable server error status code {res.status_code} ({res.reason}) - {len(events)} reports queued")
+            raise Exception(f"DIS server returned recoverable server error (HTTP Status: {res.status_code} ({res.reason})) - {len(events)} reports queued") 
 
         if 400 <= res.status_code < 500:
             # Not considered recoverable - so clear the queue
             self._events = {}
-            raise Exception(f"DIS server returned client error status code {res.status_code} ({res.reason})")
+            raise Exception(f"DIS server returned client error (HTTP Status: {res.status_code} ({res.reason})")
 

--- a/arbor-monitor/dis_client_sdk/DisClient.py
+++ b/arbor-monitor/dis_client_sdk/DisClient.py
@@ -35,19 +35,16 @@ class DisClient(object):
         self._staged_limit = staged_limit
         self._events = {}
 
-        res = requests.get(f"{base_url}/client/me?api_key={api_key}")
+    def get_info(self):
+        res = requests.get(f"{self._base_url}/client/me?api_key={api_key}")
 
         if res.status_code == 401:
-            raise Exception(
-                "Not authorized.  Check that your API Key is correct.")
+            raise Exception("Not authorized.  Check that your API Key is correct.")
 
-        if res.status_code >= 400:
-            raise Exception(res.json())
+        if res.status_code != 200:
+            raise Exception(f"DIS server returned status code {res.status_code} ({res.reason})")
 
-        self._me = res.json()
-
-    def get_info(self):
-        return self._me
+        return res.json()
 
     def get_dest(self):
         return self._dest_url

--- a/arbor-monitor/dis_client_sdk/DisClient.py
+++ b/arbor-monitor/dis_client_sdk/DisClient.py
@@ -36,7 +36,7 @@ class DisClient(object):
         self._events = {}
 
     def get_info(self):
-        res = requests.get(f"{self._base_url}/client/me?api_key={api_key}")
+        res = requests.get(f"{self._base_url}/client/me?api_key={self._key}")
 
         if res.status_code == 401:
             raise Exception("Not authorized.  Check that your API Key is correct.")

--- a/arbor-monitor/dis_client_sdk/DisClient.py
+++ b/arbor-monitor/dis_client_sdk/DisClient.py
@@ -42,7 +42,7 @@ class DisClient(object):
             raise Exception("Not authorized.  Check that your API Key is correct.")
 
         if res.status_code != 200:
-            raise Exception(f"DIS server returned status code {res.status_code} ({res.reason})")
+            raise Exception(f"DIS server returned status code {res.status_code} accessing {self._base_url} ({res.reason})")
 
         return res.json()
 


### PR DESCRIPTION
This change will just log a warning message when the DIS client cannot connect to the backend.

e.g.

```
dis-arbor-sl-monitor: WARNING Error getting client info from DIS server: DIS server returned status code 502 accessing https://api.dissarm.net/v1 (Bad Gateway)
dis-arbor-sl-monitor: INFO Found Arbor Sightline SP API version 7 at https://lab-arbos01.cablelabs.com/api/sp
Running on https://0.0.0.0:8443 (CTRL + C to quit)
```

From the commit message:

    Changed DisClient constructor to not retrieve info on construct
    
    The client info isn't retrieved until DisClient.get_info()
     is called. And this now throws an exception on anything but
     a 200 status code.
    
    Also made the dis_arbor_monitor main routine catch any
     exception on a call to DisClient.get_info() and log
     it as a warn instead of bailing out.

