### PR TITLE
Http status align

### DIFF
--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -68,7 +68,7 @@ async def process_sightline_webhook_notification():
 
     response = get_src_traffic_report(attack_id)
     if response.status_code != 200:
-        msg=f"Error retrieving the source traffic report for attack {attack_id}: {response.reason} ({response.content}))"
+        msg=f"Error retrieving the source traffic report for attack {attack_id}: (HTTP Status: {response.status_code} ({response.reason})) ({response.content}))"
         logger.warning(msg)
         # Returning a 404 so Netscout so we can try to retrieve the report again
         return jsonify({"error": msg}), 404, {'Content-Type': 'application/json'}
@@ -115,7 +115,7 @@ def check_sightline_api_supported():
                             verify=not args.arbor_api_insecure,
                             headers={"X-Arbux-APIToken":args.arbor_api_token})
     if response.status_code != requests.codes.ok:
-        logger.error(f"Error retrieving {response.url}: Status code {response.status_code}")
+        logger.error(f"Error retrieving {response.url}: (HTTP Status: {response.status_code} ({response.reason}))")
         return False
 
     json_response = response.json()

--- a/arbor-monitor/dis_client_sdk/DisClient.py
+++ b/arbor-monitor/dis_client_sdk/DisClient.py
@@ -42,7 +42,7 @@ class DisClient(object):
             raise Exception("Not authorized.  Check that your API Key is correct.")
 
         if res.status_code != 200:
-            raise Exception(f"DIS server returned status code {res.status_code} accessing {self._base_url} ({res.reason})")
+            raise Exception(f"DIS server returned (HTTP Status: {res.status_code} ({res.reason})) accessing {self._base_url} ({res.reason})")
 
         return res.json()
 
@@ -117,14 +117,14 @@ class DisClient(object):
 
         if 200 <= res.status_code < 400:
             self._events = {}
-            return f"Sent {len(events)} events to {self._base_url} (status {res.status_code} ({res.reason}))"
+            return f"Sent {len(events)} events to {self._base_url} (HTTP Status: {res.status_code} ({res.reason}))"
 
         if 500 <= res.status_code < 600 or res.status_code == 401:
             # Can be remedied on the server side - throw an error but don't clear the queue
-            raise Exception(f"DIS server returned recoverable server error status code {res.status_code} ({res.reason}) - {len(events)} reports queued")
+            raise Exception(f"DIS server returned recoverable server error (HTTP Status: {res.status_code} ({res.reason})) - {len(events)} reports queued") 
 
         if 400 <= res.status_code < 500:
             # Not considered recoverable - so clear the queue
             self._events = {}
-            raise Exception(f"DIS server returned client error status code {res.status_code} ({res.reason})")
+            raise Exception(f"DIS server returned client error (HTTP Status: {res.status_code} ({res.reason})")
 


### PR DESCRIPTION
Created this patch to align all logging of http status codes to: "(HTTP Status: {response.status_code} ({response.reason}))" to assure easy grepping / checking in the logs. Tried to align, with making minor changes to surrounding log messages to not break other integrations (too much).