### PR TITLE
Ignore DOS Destinations

### DIFF
--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -1,8 +1,9 @@
 from quart import Quart,request, jsonify
 import json, requests, logging, logging.handlers, socket, asyncio, os, argparse, dateutil.parser, time, setproctitle
-from ipaddress import IPv4Address, IPv4Network, IPv6Network, ip_network
+from ipaddress import IPv4Address, IPv4Network, IPv6Network, ip_network, ip_address
 from dis_client_sdk import DisClient
 from pathlib import Path
+from typing import List, Union
 
 #disable Warning for SSL.
 requests.packages.urllib3.disable_warnings()
@@ -55,8 +56,8 @@ async def process_sightline_webhook_notification():
 
     attack_subobjects = attack_attributes["subobject"]
 
-    destination_ip = attack_subobjects['host_address']
-    if destination_ip in args.ignore_destinations:
+    destination_ip = ip_address(attack_subobjects['host_address'])
+    if any([destination_ip in network for network in args.ignore_destinations]):
         logger.info(f"Ignoring alert {attack_id}. Destination {destination_ip} is in ignore list.")
         return "Ignoring due to destination IP", 200, {'Content-Type': 'text/plain'}
 
@@ -381,6 +382,20 @@ async def perform_periodic_status_reports(report_interval_mins):
 
 # MAIN
 
+
+def get_list_of_networks(data: str) -> List[Union[IPv4Network, IPv6Network]]:
+    """
+    Split sting of IP networks to a list of IP Network Objects
+    >>> assert [IPv4Network('10.0.0.0/24'), IPv6Network('2001:db8::/64')] == get_list_of_networks('10.0.0.0/24 2001:db8::/64')
+    >>> assert [] == get_list_of_networks('')
+    :param data:
+    :return:
+    """
+    if not data:
+        return []
+    return [ip_network(net) for net in data.split(' ')]
+
+
 arg_parser = argparse.ArgumentParser(description='Monitors for Arbor attack events and posts source address reports "'
                                                  'to the specified event consumer')
 
@@ -494,8 +509,8 @@ arg_parser.add_argument ('--report-store-format', "-repf", required=False, actio
                          default=os.environ.get('DIS_ARBORMON_REPORT_STORE_FORMAT', "only-source-attributes"),
                          help="Specify the report format to use when writing reports "
                               f"(or DIS_ARBORMON_REPORT_STORE_FORMAT). One of {storage_format_choices}")
-arg_parser.add_argument('--ignore-destinations', required=False, nargs='+',
-                        default=str.split(os.environ.get('DIS_ARBORMON_IGNORE_DESTINATIONS', "")),
+arg_parser.add_argument('--ignore-destinations', required=False, nargs='+', type=ip_network,
+                        default=get_list_of_networks(os.environ.get('DIS_ARBORMON_IGNORE_DESTINATIONS')),
                         help="Specify space-separated list of DOS destination IPs to ignore. "
                         " (or DIS_ARBORMON_IGNORE_DESTINATIONS)")
 

--- a/arbor-monitor/__main__.py
+++ b/arbor-monitor/__main__.py
@@ -495,7 +495,7 @@ arg_parser.add_argument ('--report-store-format', "-repf", required=False, actio
                          help="Specify the report format to use when writing reports "
                               f"(or DIS_ARBORMON_REPORT_STORE_FORMAT). One of {storage_format_choices}")
 arg_parser.add_argument('--ignore-destinations', required=False, nargs='+',
-                        default=os.environ.get('DIS_ARBORMON_IGNORE_DESTINATIONS', []),
+                        default=str.split(os.environ.get('DIS_ARBORMON_IGNORE_DESTINATIONS', "")),
                         help="Specify space-separated list of DOS destination IPs to ignore. "
                         " (or DIS_ARBORMON_IGNORE_DESTINATIONS)")
 

--- a/arbormon-container.conf
+++ b/arbormon-container.conf
@@ -25,3 +25,4 @@ DEF_REPORT_STORE_DIR=
 DEF_REPORT_STORE_FORMAT=only-source-attributes
 DEF_WEBHOOK_TEST_URI=http://localhost:8080/dis/sl-webhook
 DEF_DEBUG=
+DIS_ARBORMON_IGNORE_DESTINATIONS= # space-separated list of DOS destination IPs to ignore.

--- a/docs/arbor-install-guide.md
+++ b/docs/arbor-install-guide.md
@@ -1,6 +1,6 @@
 # Installation Guide for the DDoS Info Sharing (DIS) Netscout Arbor Sightline Monitor/Client
 
-### v 0.5
+### v 0.6
 
 ## 1. Introduction
 
@@ -16,7 +16,7 @@ Monitor/Client for Sightline 9.x systems.
 
 ## 2. Create an API key for the Monitor/Client
 
-Using the provided credentials, go to <https://dissarm.net/clients> and select
+Using the provided credentials, go to <https://<dis-server>/clients> and select
 "Provision New Client."
 
 NOTE: If you don’t already have credentials for the DIS management system,
@@ -83,7 +83,7 @@ The DIS Arbor Monitor/Client requires the following:
         http://arbor-hostname-or-ip/)
 
     -   A network connection allowing outbound HTTPS connections (specifically
-        to <https://dissarm.net/>)
+        to <https://<dis_site/>)
 
     -   Optionally, a https server certificate that the Sightline 9.x system can
         use to validate the server (when configuring Sightline webhooks using


### PR DESCRIPTION
I would like to propose a new option to ignore DOS Target destinations. 
It may be useful in some situation when Arbor DOS events should be ignored on the DIS client. 